### PR TITLE
トップページのカテゴリの見出しをテキスト化など

### DIFF
--- a/app/assets/stylesheets/_c-card-list.scss
+++ b/app/assets/stylesheets/_c-card-list.scss
@@ -1,6 +1,6 @@
 @import "variables";
 .c-card-list {
-  justify-content: space-between;
+  justify-content: space-around;
   display: flex;
   flex-wrap: wrap;
   @media (max-width:$SP_MAX_WIDTH){

--- a/app/assets/stylesheets/_c-card-list.scss
+++ b/app/assets/stylesheets/_c-card-list.scss
@@ -49,10 +49,22 @@
   }
   &__sub-category {
     border-radius: 20px;
-    background: #86c2fb;
     color: #f2f2f2;
     font-size: 0.8em;
     padding: 0.1em 1em;
+
+    &--10 {
+      background: #86c2fb;
+    }
+    &--20 {
+      background: #f9e4c0;
+    }
+    &--30 {
+      background: #ece688;
+    }
+    &--40 {
+      background: #d5f3b6;
+    }
   }
   &__sub-like {
   }

--- a/app/assets/stylesheets/_c-category-heading.scss
+++ b/app/assets/stylesheets/_c-category-heading.scss
@@ -1,0 +1,11 @@
+@import "variables";
+.c-category-heading {
+  text-align: center;
+  padding: 1.5em;
+  &__title {
+    font-size: 1em;
+  }
+  &__sub-title {
+    font-size: 0.8em;
+  }
+}

--- a/app/views/components/_cards.erb
+++ b/app/views/components/_cards.erb
@@ -7,8 +7,8 @@
           <%= image_tag url_for(post.image), class: 'c-card-list__body-image' %>
         </div>
         <div class="c-card-list__sub">
-          <div class="c-card-list__sub-category">
-            TODO: カテゴリ
+          <div class="c-card-list__sub-category <%="c-card-list__sub-category--#{post.category_before_type_cast}"%>">
+            <%= post.category %>
           </div>
           <div class="c-card-list__sub-like">
             <%= link_to("/posts/#{post.id}") do %>

--- a/app/views/home/top.html.erb
+++ b/app/views/home/top.html.erb
@@ -23,9 +23,13 @@
 </div>
 
 <section class="main-posts-index section">
-  <div class="newest container">
-    <%= image_tag('/img02.png') %>
-    <%= image_tag('/img03.png') %></h2>
+  <div class="c-category-heading">
+    <div class="c-category-heading__title">
+      新着アイデア
+    </div>
+    <div class="c-category-heading__sub-title">
+      NEW
+    </div>
   </div>
 
   <%= render "components/cards", posts: @posts %>
@@ -36,9 +40,13 @@
 </section>
 
 <section class="main-posts-index section">
-  <div class="popularity container">
-    <%= image_tag('/img04.png') %>
-    <%= image_tag('/img05.png') %>
+  <div class="c-category-heading">
+    <div class="c-category-heading__title">
+      注目アイデア
+    </div>
+    <div class="c-category-heading__sub-title">
+      POPULAR
+    </div>
   </div>
 
   <%= render "components/cards", posts: @likes %>
@@ -49,9 +57,13 @@
 </section>
 
 <section class="main-posts-index section">
-  <div class="popularity container">
-    <%= image_tag('/img06.png') %>
-    <%= image_tag('/img07.png') %>
+  <div class="c-category-heading">
+    <div class="c-category-heading__title">
+      最近更新されたアイデア
+    </div>
+    <div class="c-category-heading__sub-title">
+      RECENTLY UPDATED
+    </div>
   </div>
 
   <%= render "components/cards", posts: @posts_updated_order %>
@@ -62,9 +74,13 @@
 </section>
 
 <section class="main-posts-index section">
-  <div class="popularity container">
-    <%= image_tag('/img08.png') %>
-    <%= image_tag('/img09.png') %>
+  <div class="c-category-heading">
+    <div class="c-category-heading__title">
+      ランダム
+    </div>
+    <div class="c-category-heading__sub-title">
+      RANDOM
+    </div>
   </div>
 
   <%= render "components/cards", posts: @posts_random %>


### PR DESCRIPTION
- トップページのカテゴリの見出しをテキスト化
- 幅変更時の、カードの両側の空白を均等になるように調整
- カードのカテゴリの表示を動的にして、色もそれぞれに割り当て。